### PR TITLE
zero deregistration delay

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,39 @@
+name: Quick Tests
+on:
+  push:
+  # Scheduled runs ensure we are alerted to incompatibilities in new releases
+  # of Terraform.
+  schedule:
+    - cron: '0 10 * * 3'
+
+jobs:
+
+  terraform:
+    name: Terraform Validation
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version:
+          - "latest"
+          - "1.0.7"  # Per https://github.com/PSPinc/core-cloud-devops/pull/90
+
+    steps:
+
+      - uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: '${{ matrix.version }}'
+
+      - uses: actions/checkout@v2
+
+      - name: Terraform fmt
+        id: fmt
+        run: terraform fmt -check
+        continue-on-error: true
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+#
+# IntelliJ
+#
+.idea/
+
+
+#
+# Vim
+#
+*.swp
+
+
+#
+# Terraform
+#
+.terraform/
+# Until we upgrade Terraform version in `versions.tf`
+.terraform.lock.hcl

--- a/main.tf
+++ b/main.tf
@@ -91,9 +91,9 @@ resource "aws_security_group" "bastion_to_instance_sg" {
   vpc_id      = var.vpc_id
 
   ingress {
-    protocol  = "tcp"
-    from_port = 22
-    to_port   = 22
+    protocol        = "tcp"
+    from_port       = 22
+    to_port         = 22
     security_groups = [
       aws_security_group.this.id,
     ]
@@ -161,10 +161,11 @@ resource "aws_lb" "this" {
 }
 
 resource "aws_lb_target_group" "this" {
-  port        = 22
-  protocol    = "TCP"
-  vpc_id      = var.vpc_id
-  target_type = "instance"
+  port                 = 22
+  protocol             = "TCP"
+  vpc_id               = var.vpc_id
+  target_type          = "instance"
+  deregistration_delay = 0
 
   health_check {
     port     = "traffic-port"


### PR DESCRIPTION
By default `aws_lb_target_group` has a [deregistration delay](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group#deregistration_delay) of 300 seconds.  There is need for this in the case of a bastion host; and it needlessly prolongs the duration of a `terraform apply` run.

This PR reduces the deregistration delay to 0 seconds.

This PR also adds a Github Action workflow that runs automated validation on the Terraform code; and a `.gitignore` file that ignores various files.

