### PR TITLE
bump aws provider version to ~> 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ==========
 
+* Update AWS provider required version to ~> 3.0
+
 1.0.0
 =====
 * Syntax updates to 0.13.1

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,9 @@
 terraform {
   required_version = ">= 0.13.1"
   required_providers {
-    aws = {
+    aws      = {
       source  = "hashicorp/aws"
-      version = "~> 3.55.0"
+      version = "~> 3.0"
     }
     template = {
       source  = "hashicorp/template"


### PR DESCRIPTION
This PR updates the AWS provider version specified in `versions.tf` to `~> 3.0`, for compatibility with work for our client.  