### PR TITLE
Fix deprecated S3 syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ==========
 
+* Add a Makefile for convenience
+
 2.0.0
 =====
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ Unreleased
 ==========
 
 * Add a Makefile for convenience
+* Update syntax for `aws_s3_bucket`
+* Remove `lifecycle ignore_changes` workaround for issue where live
+  infrastructure never conformed with TF, making TF constantly want to re-grant
+  the same grant.  Issue was eliminated after the switch to new syntax.
+
 
 2.0.0
 =====

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,82 @@
+#===============================================================================
+#
+# Terraform Makefile
+#
+#===============================================================================
+
+#-------------------------------------------------------------------------------
+# Configuration
+#-------------------------------------------------------------------------------
+vault_profile = cs-dev
+
+
+#-------------------------------------------------------------------------------
+# Local variables
+#-------------------------------------------------------------------------------
+vault_exec = aws-vault exec $(vault_profile) --
+#tf = $(vault_exec) terraform
+tf = terraform
+ifc = $(vault_exec) infracost
+
+
+#-------------------------------------------------------------------------------
+# Pipeline targets
+#-------------------------------------------------------------------------------
+all: init validate checkov
+
+
+#-------------------------------------------------------------------------------
+# Other targets
+#-------------------------------------------------------------------------------
+
+# Terraform commands, run via aws-vault
+apply:
+	$(tf) apply
+destroy:
+	$(tf) destroy
+init:
+	$(tf) init
+plan: validate
+	$(tf) plan
+validate:
+	$(tf) validate
+
+
+# Checkov static analysis
+checkov:
+	if [ -s .checkov.baseline ]; then \
+  		make checkov_baseline; \
+  	else \
+  	  	make checkov_full; \
+  	fi
+checkov_full:
+	checkov --quiet --compact --framework terraform --directory .
+checkov_create_baseline:
+	checkov --quiet --create-baseline --framework terraform --directory .
+checkov_baseline:
+	checkov --quiet --compact --framework terraform --baseline .checkov.baseline --directory .
+
+
+
+# AWS Vault clear all session keys
+clear:
+	aws-vault clear
+
+
+infracost-breakdown:
+	$(ifc) breakdown --path .
+infracost-diff:
+	$(ifc) diff --path .
+
+yor:
+	yor tag -d .
+
+# Developer tools
+install_tools:
+	# Asdf version manager must already be installed
+	asdf plugin-add aws-vault
+	asdf plugin-add yor
+	asdf install
+	pip install -U pip
+	pip install -U checkov 
+	asdf reshim

--- a/main.tf
+++ b/main.tf
@@ -50,11 +50,11 @@ resource "aws_s3_bucket" "this" {
 
   tags = var.tags
 
-    # Workaround for issue where live infrastructure never conforms with TF,
-    # making TF constantly want to re-grant the same grant.
-    lifecycle {
-      ignore_changes = [grant]
-    }
+  #  # Workaround for issue where live infrastructure never conforms with TF,
+  #  # making TF constantly want to re-grant the same grant.
+  #  lifecycle {
+  #    ignore_changes = [grant]
+  #  }
 }
 
 resource "aws_s3_bucket_acl" "this" {

--- a/main.tf
+++ b/main.tf
@@ -47,14 +47,7 @@ data "aws_canonical_user_id" "current_user" {}
 
 resource "aws_s3_bucket" "this" {
   bucket = coalesce(var.bucket_name, "${local.bastion_name}-storage")
-
-  tags = var.tags
-
-  #  # Workaround for issue where live infrastructure never conforms with TF,
-  #  # making TF constantly want to re-grant the same grant.
-  #  lifecycle {
-  #    ignore_changes = [grant]
-  #  }
+  tags   = var.tags
 }
 
 resource "aws_s3_bucket_acl" "this" {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  region   = coalesce(var.region, data.aws_region.current.name)
+  region       = coalesce(var.region, data.aws_region.current.name)
   bastion_name = "${var.vpc_name}-bastion"
 }
 
@@ -48,22 +48,37 @@ data "aws_canonical_user_id" "current_user" {}
 resource "aws_s3_bucket" "this" {
   bucket = coalesce(var.bucket_name, "${local.bastion_name}-storage")
 
-  grant {
-    id          = data.aws_canonical_user_id.current_user.id
-    type        = "CanonicalUser"
-    permissions = ["FULL_CONTROL"]
-  }
-
-  versioning {
-    enabled = var.enable_bucket_versioning
-  }
-
   tags = var.tags
 
-  # Workaround for issue where live infrastructure never conforms with TF,
-  # making TF constantly want to re-grant the same grant.
-  lifecycle {
-    ignore_changes = [grant]
+    # Workaround for issue where live infrastructure never conforms with TF,
+    # making TF constantly want to re-grant the same grant.
+    lifecycle {
+      ignore_changes = [grant]
+    }
+}
+
+resource "aws_s3_bucket_acl" "this" {
+  bucket = aws_s3_bucket.this.id
+  access_control_policy {
+    grant {
+      grantee {
+        id   = data.aws_canonical_user_id.current_user.id
+        type = "CanonicalUser"
+      }
+      permission = "FULL_CONTROL"
+    }
+
+    owner {
+      id = data.aws_canonical_user_id.current_user.id
+    }
+
+  }
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+  versioning_configuration {
+    status = var.enable_bucket_versioning ? "Enabled" : "Disabled"
   }
 }
 
@@ -102,9 +117,9 @@ resource "aws_security_group" "bastion_to_instance_sg" {
   tags        = var.tags
 
   ingress {
-    protocol        = "tcp"
-    from_port       = 22
-    to_port         = 22
+    protocol  = "tcp"
+    from_port = 22
+    to_port   = 22
     security_groups = [
       aws_security_group.this.id,
     ]

--- a/variables.tf
+++ b/variables.tf
@@ -81,6 +81,6 @@ variable "tags" {
 }
 
 variable "vpc_name" {
-  type = string
+  type        = string
   description = "Name of the VPC this bastion serves"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = ">= 0.13.1"
   required_providers {
-    aws      = {
+    aws = {
       source  = "hashicorp/aws"
       version = "~> 3.0"
     }


### PR DESCRIPTION
This PR updates `aws_s3_syntax`, removing deprecated clauses and replacing them with corresponding ancillary resources.

This PR also adds a `Makefile` for convenience; and removes a workaround for an issue that disappeared when we updated the syntax.