### PR TITLE
Security hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ==========
 
+* Security hardening with Ansible role `geerlingguy.security`
+
 2.1.0
 =====
 

--- a/main.tf
+++ b/main.tf
@@ -234,7 +234,7 @@ resource "aws_autoscaling_group" "this" {
   max_size             = var.max_count
   min_size             = var.min_count
   desired_capacity     = var.desired_count
-  health_check_type    = "ELB"
+  health_check_type    = "EC2"
 
   vpc_zone_identifier = var.asg_subnets
 

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ data "template_file" "user_data" {
     aws_region        = local.region
     bucket_name       = aws_s3_bucket.this.bucket
     sync_users_script = data.template_file.sync_users.rendered
-    sudoers           = var.sudoers
+    sudoers           = '[${join(", ", var.sudoers)}]'
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,6 @@
 locals {
   region         = coalesce(var.region, data.aws_region.current.name)
   bastion_name   = "${var.vpc_name}-bastion"
-  sudoers_string = join(", ", var.sudoers)
 }
 
 data "aws_region" "current" {
@@ -32,7 +31,7 @@ data "template_file" "user_data" {
     aws_region        = local.region
     bucket_name       = aws_s3_bucket.this.bucket
     sync_users_script = data.template_file.sync_users.rendered
-    sudoers           = "[${local.sudoers_string}]"
+    sudoers           = jsonencode(var.sudoers)
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,7 @@ data "template_file" "user_data" {
     aws_region        = local.region
     bucket_name       = aws_s3_bucket.this.bucket
     sync_users_script = data.template_file.sync_users.rendered
+    sudoers           = var.sudoers
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -234,7 +234,7 @@ resource "aws_autoscaling_group" "this" {
   max_size             = var.max_count
   min_size             = var.min_count
   desired_capacity     = var.desired_count
-  health_check_type    = "EC2"
+  health_check_type    = "ELB"
 
   vpc_zone_identifier = var.asg_subnets
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 locals {
-  region       = coalesce(var.region, data.aws_region.current.name)
-  bastion_name = "${var.vpc_name}-bastion"
+  region         = coalesce(var.region, data.aws_region.current.name)
+  bastion_name   = "${var.vpc_name}-bastion"
+  sudoers_string = join(", ", var.sudoers)
 }
 
 data "aws_region" "current" {
@@ -31,7 +32,7 @@ data "template_file" "user_data" {
     aws_region        = local.region
     bucket_name       = aws_s3_bucket.this.bucket
     sync_users_script = data.template_file.sync_users.rendered
-    sudoers           = '[${join(", ", var.sudoers)}]'
+    sudoers           = "[${local.sudoers_string}]"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -242,6 +242,11 @@ resource "aws_autoscaling_group" "this" {
   termination_policies = ["OldestLaunchConfiguration"]
   force_delete         = true
 
+  instance_refresh {
+    strategy = "Rolling"
+    triggers = ["tag"]
+  }
+
   tag {
     key                 = "Name"
     value               = aws_launch_configuration.this.name

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
-  region         = coalesce(var.region, data.aws_region.current.name)
-  bastion_name   = "${var.vpc_name}-bastion"
+  region       = coalesce(var.region, data.aws_region.current.name)
+  bastion_name = "${var.vpc_name}-bastion"
 }
 
 data "aws_region" "current" {

--- a/main.tf
+++ b/main.tf
@@ -277,11 +277,5 @@ resource "aws_launch_configuration" "this" {
 
   lifecycle {
     create_before_destroy = true
-
-    # If we do not ignore changes, user_data will be updated on every apply,
-    # even if nothing has changed.
-    ignore_changes = [user_data]
   }
 }
-
-# TODO: harden the instances, add route 53 entries

--- a/user_data.sh.tmpl
+++ b/user_data.sh.tmpl
@@ -79,6 +79,8 @@ ansible-galaxy install geerlingguy.security
 cat > /opt/playbook.yaml << EOF
 - hosts: localhost
   gather_facts: true
+  vars:
+    security_sudoers_passwordless: ${sudoers}
   roles:
     - geerlingguy.security
 EOF

--- a/user_data.sh.tmpl
+++ b/user_data.sh.tmpl
@@ -76,7 +76,7 @@ amazon-linux-extras install epel -y
 pip3 install ansible
 ansible-galaxy install geerlingguy.security
 
-cat > /opt/playbook.yaml << EOF
+cat > ~/playbook.yaml << EOF
 - hosts: localhost
   gather_facts: true
   vars:
@@ -85,6 +85,6 @@ cat > /opt/playbook.yaml << EOF
     - geerlingguy.security
 EOF
 
-ansible-playbook /opt/playbook.yaml
+ansible-playbook ~/playbook.yaml
 
 

--- a/user_data.sh.tmpl
+++ b/user_data.sh.tmpl
@@ -72,7 +72,7 @@ rm ~/mycron
 #-------------------------------------------------------------------------------
 
 yum -y update --security
-amazon-linux-extras install epel -y
+amazon-linux-extras install epel -y   # Required for Ansible role geerlingguy.security
 pip3 install ansible
 ansible-galaxy install geerlingguy.security
 

--- a/user_data.sh.tmpl
+++ b/user_data.sh.tmpl
@@ -1,8 +1,32 @@
 #!/bin/bash -x
+
+#===============================================================================
+#
+# Hardening
+#
+#-------------------------------------------------------------------------------
+
 yum -y update --security
+amazon-linux-extras install epel -y
+pip3 install ansible
+ansible-galaxy install geerlingguy.security
 
-# initiate hardening here
+cat > /opt/playbook.yaml << EOF
+- hosts: localhost
+  gather_facts: true
+  roles:
+    - geerlingguy.security
+EOF
 
+ansible-playbook /opt/playbook.yaml
+#===============================================================================
+
+
+#===============================================================================
+#
+# Sync Users
+#
+#-------------------------------------------------------------------------------
 mkdir -p /usr/bin/bastion/
 cat > /usr/bin/bastion/sync_users << 'EOF'
 #!/usr/bin/env bash

--- a/user_data.sh.tmpl
+++ b/user_data.sh.tmpl
@@ -1,32 +1,10 @@
 #!/bin/bash -x
 
-#===============================================================================
-#
-# Hardening
-#
+
 #-------------------------------------------------------------------------------
-
-yum -y update --security
-amazon-linux-extras install epel -y
-pip3 install ansible
-ansible-galaxy install geerlingguy.security
-
-cat > /opt/playbook.yaml << EOF
-- hosts: localhost
-  gather_facts: true
-  roles:
-    - geerlingguy.security
-EOF
-
-ansible-playbook /opt/playbook.yaml
-#===============================================================================
-
-
-#===============================================================================
-#
 # Sync Users
-#
 #-------------------------------------------------------------------------------
+
 mkdir -p /usr/bin/bastion/
 cat > /usr/bin/bastion/sync_users << 'EOF'
 #!/usr/bin/env bash
@@ -87,3 +65,24 @@ crontab ~/mycron
 rm ~/mycron
 
 /usr/bin/bastion/sync_users
+
+
+#-------------------------------------------------------------------------------
+# Hardening
+#-------------------------------------------------------------------------------
+
+yum -y update --security
+amazon-linux-extras install epel -y
+pip3 install ansible
+ansible-galaxy install geerlingguy.security
+
+cat > /opt/playbook.yaml << EOF
+- hosts: localhost
+  gather_facts: true
+  roles:
+    - geerlingguy.security
+EOF
+
+ansible-playbook /opt/playbook.yaml
+
+

--- a/variables.tf
+++ b/variables.tf
@@ -49,7 +49,7 @@ variable "min_count" {
 
 variable "instance_type" {
   description = "Instance type for the bastion host. Default = t2.nano"
-  default     = "t2.nano"
+  default     = "t3a.micro"  # nano is too weak to run ansible role geerlingguy.security
 }
 
 variable "associate_public_ip_address" {

--- a/variables.tf
+++ b/variables.tf
@@ -84,3 +84,9 @@ variable "vpc_name" {
   type        = string
   description = "Name of the VPC this bastion serves"
 }
+
+variable "sudoers" {
+  type        = list(string)
+  description = "Usernames that will be granted passwordless sudo privilege"
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -49,7 +49,7 @@ variable "min_count" {
 
 variable "instance_type" {
   description = "Instance type for the bastion host. Default = t2.nano"
-  default     = "t3a.micro"  # nano is too weak to run ansible role geerlingguy.security
+  default     = "t3a.micro" # nano is too weak to run ansible role geerlingguy.security
 }
 
 variable "associate_public_ip_address" {


### PR DESCRIPTION
This PR adds security hardening via Ansible role [`geerlingguy.security`](https://github.com/geerlingguy/ansible-role-security).  It also upsizes the bastion instance type to `t3a.micro`, as a `nano` was too weak to run the new tools.